### PR TITLE
add dependabot config for actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  # Keep dependencies for GitHub Actions up-to-date
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'


### PR DESCRIPTION
Basic configuration for dependabot to periodically scan repo's github workflows and open PR for updating the actions.

This should  simplify updating and minimize manual effort like: c2deffe258c79f9da060c4f4305d9e513b01d1c0 2eb47e1c97db5deef00267b31da90e6c606a31b0 6bd426e520b4aaae100c1dbe257a12736f384090

- Dependabot [docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates#enabling-dependabot-version-updates)
- Example PR https://github.com/key4hep/key4hep-julia-fwk/pull/15